### PR TITLE
Fix download error for new builds

### DIFF
--- a/Form_yuzuEarlyAccessLauncher.cs
+++ b/Form_yuzuEarlyAccessLauncher.cs
@@ -1117,7 +1117,7 @@ namespace yuzu_Early_Access_Launcher
                         Directory.Delete("Temp", true);
                     }
                     Directory.CreateDirectory("Temp");
-                    await Extract1(path + "\\" + file, path + "\\Temp");
+                    await Extract(path + "\\" + file, path + "\\Temp");
                     log.WriteLine("Moving \"" + path + "\\Temp\\yuzu-windows-msvc-early-access\" to \"" + path + "\\yuzu-windows-msvc-early-access\"");
                     Directory.Move("Temp\\yuzu-windows-msvc-early-access", path + "\\yuzu-windows-msvc-early-access");
                     log.WriteLine(" Done");

--- a/Form_yuzuEarlyAccessLauncher.cs
+++ b/Form_yuzuEarlyAccessLauncher.cs
@@ -685,7 +685,7 @@ namespace yuzu_Early_Access_Launcher
             log.WriteLine("Checking Files");
             for (int i = 0; i < 2; i++)
             {
-                foreach (string f in Directory.EnumerateFiles(path, "Windows-Yuzu-EA-*.7z"))
+                foreach (string f in Directory.EnumerateFiles(path, "Windows-Yuzu-EA-*.zip"))
                 {
                     int fVer = int.Parse(f.Split('\\').Last().Split('-', '.')[3]);
 
@@ -770,16 +770,16 @@ namespace yuzu_Early_Access_Launcher
                 lfirm = "";
             }
 
-            file = "Windows-Yuzu-EA-" + latest + ".7z";
+            file = "Windows-Yuzu-EA-" + latest + ".zip";
             firfile = "Switch-Firmware-" + lfirm + ".zip";
 
             if (System.IO.File.Exists(file))
             {
-                log.WriteLine(" Latest found yuzu Early Access file: \"" + path + "\\Windows-Yuzu-EA-" + latest + ".7z\"");
+                log.WriteLine(" Latest found yuzu Early Access file: \"" + path + "\\Windows-Yuzu-EA-" + latest + ".zip\"");
             }
             else
             {
-                log.WriteLine(" Not found file \"" + path + "\\Windows-Yuzu-EA-" + latest + ".7z\"");
+                log.WriteLine(" Not found file \"" + path + "\\Windows-Yuzu-EA-" + latest + ".zip\"");
             }
             if (System.IO.File.Exists(firfile))
             {
@@ -1091,13 +1091,13 @@ namespace yuzu_Early_Access_Launcher
             {
                 if (!System.IO.File.Exists(file))
                 {
-                    foreach (string f in Directory.EnumerateFiles(UserProfile + "\\AppData\\Local\\Temp\\", "Windows-Yuzu-EA-*.7z"))
+                    foreach (string f in Directory.EnumerateFiles(UserProfile + "\\AppData\\Local\\Temp\\", "Windows-Yuzu-EA-*.zip"))
                     {
                         System.IO.File.Delete(f);
                     }
                     if (await Download(url, ysize, UserProfile + "\\AppData\\Local\\Temp\\" + file) == 0)
                     {
-                        foreach (string f in Directory.EnumerateFiles(path, "Windows-Yuzu-EA-*.7z"))
+                        foreach (string f in Directory.EnumerateFiles(path, "Windows-Yuzu-EA-*.zip"))
                         {
                             System.IO.File.Delete(f);
                         }
@@ -1117,7 +1117,7 @@ namespace yuzu_Early_Access_Launcher
                         Directory.Delete("Temp", true);
                     }
                     Directory.CreateDirectory("Temp");
-                    await Extract(path + "\\" + file, path + "\\Temp");
+                    await Extract1(path + "\\" + file, path + "\\Temp");
                     log.WriteLine("Moving \"" + path + "\\Temp\\yuzu-windows-msvc-early-access\" to \"" + path + "\\yuzu-windows-msvc-early-access\"");
                     Directory.Move("Temp\\yuzu-windows-msvc-early-access", path + "\\yuzu-windows-msvc-early-access");
                     log.WriteLine(" Done");


### PR DESCRIPTION
The new downloads are only in zip format so this commit will fix the error saying can't divide by 0.